### PR TITLE
Raise version bounds for non-base instances (lts-7 compat)

### DIFF
--- a/extra/data-default-extra.cabal
+++ b/extra/data-default-extra.cabal
@@ -116,8 +116,8 @@ library
 
   build-depends:
       base <6
-    , data-default-class ==0.0.*
-    , data-default-instances-base ==0.0.*
+    , data-default-class <0.2
+    , data-default-instances-base <0.2
     , data-default-instances-new-base ==0.0.*
 
   if impl(ghc <7.6)

--- a/instances-bytestring/data-default-instances-bytestring.cabal
+++ b/instances-bytestring/data-default-instances-bytestring.cabal
@@ -60,7 +60,7 @@ library
     , bytestring >=0.9 && <1
     -- ^ Version 0.9 is the oldest available on Hackage.
 
-    , data-default-class ==0.0.*
+    , data-default-class <0.2
 
   ghc-options:          -Wall -fwarn-tabs
 

--- a/instances-case-insensitive/data-default-instances-case-insensitive.cabal
+++ b/instances-case-insensitive/data-default-instances-case-insensitive.cabal
@@ -36,7 +36,7 @@ library
 
   build-depends:
       case-insensitive >=0.1 && <2
-    , data-default-class ==0.0.*
+    , data-default-class <0.2
 
   ghc-options:          -Wall -fwarn-tabs
 

--- a/instances-new-base/data-default-instances-new-base.cabal
+++ b/instances-new-base/data-default-instances-new-base.cabal
@@ -80,8 +80,8 @@ library
   build-depends:
       base >=4 && <5
     -- ^ Probably even lower version of base could be supported.
-    , data-default-class ==0.0.*
-    , data-default-instances-base ==0.0.*
+    , data-default-class <0.2
+    , data-default-instances-base <0.2
 
   ghc-options:          -Wall -fwarn-tabs
 

--- a/instances-text/data-default-instances-text.cabal
+++ b/instances-text/data-default-instances-text.cabal
@@ -52,7 +52,7 @@ library
     , text >=0.2 && <2
     -- ^ Version 0.2 is the first that provided both strict and lazy Text.
 
-    , data-default-class ==0.0.*
+    , data-default-class <0.2
 
   ghc-options:          -Wall -fwarn-tabs
 

--- a/instances-unordered-containers/data-default-instances-unordered-containers.cabal
+++ b/instances-unordered-containers/data-default-instances-unordered-containers.cabal
@@ -39,7 +39,7 @@ library
       unordered-containers >=0.1.3 && <0.3
     -- ^ Version 0.1.3 is the first one that introduced HashSet.
 
-    , data-default-class ==0.0.*
+    , data-default-class <0.2
 
   ghc-options:          -Wall -fwarn-tabs
 

--- a/instances-vector/data-default-instances-vector.cabal
+++ b/instances-vector/data-default-instances-vector.cabal
@@ -41,7 +41,7 @@ library
 
   build-depends:
       vector >=0.5 && <1
-    , data-default-class ==0.0.*
+    , data-default-class <0.2
 
   ghc-options:          -Wall -fwarn-tabs
 


### PR DESCRIPTION
Apparently these build with new data-default-class just fine.

Can you please release a new version of these packages or (preferably)
just edit the version bounds on hackage? Thanks!